### PR TITLE
update nix crate to 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "log"
@@ -45,9 +45,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "init"
 path = "src/main.rs"
 
 [dependencies]
-nix = { version = "0.29", features = ["fs", "mount", "process", "term"], default-features = false }
+nix = { version = "0.30.1", features = ["fs", "mount", "process", "term"], default-features = false }
 getrandom = { version = "0.2.15" }
 log = { version = "0.4.21", features = ["std"], default-features = false}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::fmt::Write as _;
 use std::fs::{create_dir, read_to_string, File, OpenOptions};
 use std::io;
 use std::io::Write as _;
-use std::os::fd::{AsFd, AsRawFd, RawFd};
+use std::os::fd::AsFd;
 use std::os::unix::ffi::OsStrExt;
 use std::panic::set_hook;
 use std::path::Path;
@@ -21,7 +21,7 @@ use mount::{mount_move_special, mount_root, mount_special};
 #[cfg(feature = "reboot-on-failure")]
 use nix::sys::reboot::{reboot, RebootMode};
 use nix::sys::termios::tcdrain;
-use nix::unistd::{chdir, chroot, dup2, execv, unlink};
+use nix::unistd::{chdir, chroot, dup2_stderr, dup2_stdout, execv, unlink};
 #[cfg(feature = "systemd")]
 use systemd::{mount_systemd, shutdown};
 #[cfg(feature = "usb9pfs")]
@@ -59,10 +59,10 @@ fn read_file(filename: &str) -> std::result::Result<String, String> {
  */
 fn setup_console() -> Result<()> {
     let f = OpenOptions::new().write(true).open("/dev/console")?;
-    let raw_fd: RawFd = f.as_raw_fd();
+    let fd = f.as_fd();
 
-    dup2(raw_fd, io::stdout().as_raw_fd())?;
-    dup2(raw_fd, io::stderr().as_raw_fd())?;
+    dup2_stdout(fd)?;
+    dup2_stderr(fd)?;
 
     let _ = unlink("/dev/console");
 


### PR DESCRIPTION
Use the new `dup2_stdout`/`dup2_stderr` functions, reduce `RawFd` usage.