### PR TITLE
simple readahead support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +71,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +126,24 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -44,6 +158,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "mini-internal"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560f32b6891d8d9bade8942c45a27694f16d789d3b4b8e6b7135a5240de0a8af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniserde"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac79f4123c070de643a7a93b9339abf18c30005c622bf4b1c29c2c0960f52d39"
+dependencies = [
+ "itoa",
+ "mini-internal",
+ "ryu",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,16 +202,180 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rsinit"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "getrandom",
  "log",
+ "memmap",
+ "miniserde",
  "nix",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,18 @@ path = "src/lib.rs"
 name = "init"
 path = "src/main.rs"
 
+[[bin]]
+name = "readahead"
+path = "src/bins/readahead.rs"
+required-features = ["readahead"]
+
 [dependencies]
 nix = { version = "0.30.1", features = ["feature", "fs", "mount", "process", "term"], default-features = false }
 getrandom = { version = "0.2.15" }
 log = { version = "0.4.21", features = ["std"], default-features = false}
+clap = { version = "4.5.48", features = ["derive"], optional = true }
+memmap = "0.7.0"
+miniserde = { version = "0.1.43", optional = true }
 
 [features]
 default = ["systemd", "dmverity", "usb9pfs", "reboot-on-failure"]
@@ -32,6 +40,8 @@ systemd = ["nix/reboot"]
 dmverity = ["nix/ioctl"]
 usb9pfs = []
 reboot-on-failure = ["nix/reboot"]
+readahead = ["nix/poll", "nix/signal", "nix/zerocopy", "miniserde", "clap"]
+readahead-debug = ["readahead"]
 
 [profile.release]
 opt-level = 'z'

--- a/src/bins/readahead.rs
+++ b/src/bins/readahead.rs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2024 The rsinit Authors
+// SPDX-License-Identifier: GPL-2.0-only
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+extern crate rsinit;
+
+use clap::Parser;
+use log::{LevelFilter, Log, Metadata, Record};
+use rsinit::readahead;
+
+struct DebugLogger;
+
+impl Log for DebugLogger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        println!("hit");
+        true
+    }
+    fn log(&self, record: &Record) {
+        println!("{} - {}", record.level(), record.args());
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: DebugLogger = DebugLogger;
+
+#[derive(Parser, Debug)]
+#[command(about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    trace: bool,
+    file: String,
+}
+
+fn run() -> Result<()> {
+    log::set_logger(&LOGGER)?;
+    log::set_max_level(LevelFilter::Trace);
+    let args = Args::parse();
+    if !args.trace {
+        if let Some(input) = readahead::readahead_open(&args.file)? {
+            readahead::readahead_load(&input);
+        } else {
+            println!("Trace file {} missing!", args.file);
+        }
+    } else {
+        readahead::enable_readahead_tracing(true)?;
+        let readahead = readahead::readahead_trace(true)?;
+        readahead::readahead_write(&readahead, &args.file)?;
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    if let Err(e) = run() {
+        println!("Failed: {e}");
+    }
+    Ok(())
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -12,6 +12,8 @@ use std::io::Write as _;
 use std::os::fd::AsFd;
 use std::os::unix::ffi::OsStrExt;
 use std::panic::set_hook;
+#[cfg(feature = "reboot-on-failure")]
+use std::process;
 
 use log::{debug, Level, LevelFilter, Metadata, Record};
 #[cfg(feature = "reboot-on-failure")]
@@ -26,6 +28,8 @@ use crate::mount::{
     mount_bind_kernel_modules, mount_move_special, mount_overlay, mount_root, mount_special,
     mount_tmpfs_overlay,
 };
+#[cfg(feature = "readahead")]
+use crate::readahead;
 #[cfg(feature = "systemd")]
 use crate::systemd::mount_systemd;
 #[cfg(feature = "usb9pfs")]
@@ -86,12 +90,16 @@ fn finalize() {
     /* Make sure all output is written before exiting */
     let _ = tcdrain(io::stdout().as_fd());
     #[cfg(feature = "reboot-on-failure")]
-    let _ = reboot(RebootMode::RB_AUTOBOOT);
+    if process::id() == 1 {
+        let _ = reboot(RebootMode::RB_AUTOBOOT);
+    }
 }
 
 pub struct InitContext<'a> {
     pub options: CmdlineOptions,
     parser: CmdlineOptionsParser<'a>,
+    #[cfg(feature = "readahead")]
+    pub readahead_data: Option<readahead::ReadaheadData>,
 }
 
 impl<'a> InitContext<'a> {
@@ -106,6 +114,8 @@ impl<'a> InitContext<'a> {
         Ok(Self {
             options: CmdlineOptions::default(),
             parser: CmdlineOptionsParser::new(),
+            #[cfg(feature = "readahead")]
+            readahead_data: readahead::readahead_open("/trace.json")?,
         })
     }
 
@@ -227,6 +237,10 @@ impl<'a> InitContext<'a> {
 
     pub fn finish(self: &mut InitContext<'a>) -> Result<()> {
         self.switch_root()?;
+
+        #[cfg(feature = "readahead")]
+        readahead::readahead_start(self.readahead_data.take(), "/run/trace.json")?;
+
         self.start_init()?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod cmdline;
 pub mod dmverity;
 pub mod init;
 pub mod mount;
+#[cfg(feature = "readahead")]
+pub mod readahead;
 #[cfg(feature = "systemd")]
 pub mod systemd;
 #[cfg(feature = "usb9pfs")]

--- a/src/readahead.rs
+++ b/src/readahead.rs
@@ -1,0 +1,633 @@
+// SPDX-FileCopyrightText: 2025 The rsinit Authors
+// SPDX-License-Identifier: GPL-2.0-only
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::fs::{metadata, read_dir, write, File, OpenOptions};
+use std::os::fd::{AsFd, OwnedFd};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::Path;
+#[cfg(feature = "readahead-debug")]
+use std::process;
+use std::process::exit;
+
+use log::{debug, error, warn};
+use memmap::Mmap;
+use miniserde::de::{self, Visitor};
+use miniserde::ser::{self, Fragment};
+use miniserde::{json, make_place, Deserialize, Serialize};
+use nix::errno::Errno;
+use nix::fcntl::{posix_fadvise, splice, PosixFadviseAdvice::POSIX_FADV_WILLNEED, SpliceFFlags};
+use nix::libc::{off_t, O_NONBLOCK, O_TMPFILE};
+use nix::mount::MsFlags;
+use nix::poll::{ppoll, PollFd, PollFlags};
+use nix::sys::prctl::set_name;
+use nix::sys::signal::{SigSet, Signal};
+use nix::sys::signalfd::SignalFd;
+use nix::sys::stat::{fstat, major, minor};
+use nix::unistd::{fork, pipe, ForkResult};
+
+use crate::util::Result;
+use crate::{mount::mount_apivfs, util::read_file};
+
+#[cfg(target_pointer_width = "64")]
+const SIZE_OF_LONG: usize = 8;
+
+#[cfg(target_pointer_width = "32")]
+const SIZE_OF_LONG: usize = 4;
+
+const KBUFFER_TYPE_PADDING: u32 = 29;
+const KBUFFER_TYPE_TIME_EXTEND: u32 = 30;
+const KBUFFER_TYPE_TIME_STAMP: u32 = 31;
+
+struct TraceFile {
+    trace: File,
+    pipe_read: OwnedFd,
+    pipe_write: OwnedFd,
+    tmp: File,
+    cpu: usize,
+}
+
+struct TraceData {
+    mmap: Mmap,
+    pages: usize,
+    timestamp: u64,
+    page: usize,
+    page_size: usize,
+    page_offset: usize,
+    record_end: usize,
+    record_type: u16,
+}
+
+make_place!(Place);
+
+struct ReadaheadBlock {
+    file: Option<usize>,
+    offset: u64,
+    size: u64,
+    ino: u64,
+    #[cfg(feature = "readahead-debug")]
+    pid: u32,
+}
+
+struct ReadaheadBlockStream<'a> {
+    block: &'a ReadaheadBlock,
+    file: u64,
+    pos: usize,
+}
+
+struct ReadaheadBlockBuilder<'a> {
+    out: &'a mut Option<ReadaheadBlock>,
+    file: Option<usize>,
+    offset: u64,
+    size: u64,
+    element: Option<u64>,
+    pos: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ReadaheadData {
+    files: Vec<String>,
+    blocks: Vec<ReadaheadBlock>,
+}
+
+impl<'a> ser::Seq for ReadaheadBlockStream<'a> {
+    fn next(&mut self) -> Option<&dyn Serialize> {
+        let pos = self.pos;
+        self.pos += 1;
+        match pos {
+            0 => Some(&self.file),
+            1 => Some(&self.block.offset),
+            2 => Some(&self.block.size),
+            _ => None,
+        }
+    }
+}
+
+impl Serialize for ReadaheadBlock {
+    fn begin(&self) -> Fragment<'_> {
+        Fragment::Seq(Box::new(ReadaheadBlockStream {
+            block: self,
+            file: self.file.unwrap() as u64,
+            pos: 0,
+        }))
+    }
+}
+
+impl<'a> ReadaheadBlockBuilder<'a> {
+    fn take(&mut self) {
+        if let Some(next) = self.element.take() {
+            let pos = self.pos;
+            match pos {
+                0 => self.file = Some(next as usize),
+                1 => self.offset = next,
+                2 => self.size = next,
+                _ => (),
+            }
+            self.pos += 1;
+        }
+    }
+}
+
+impl<'a> de::Seq for ReadaheadBlockBuilder<'a> {
+    fn element(&mut self) -> miniserde::Result<&mut dyn Visitor> {
+        self.take();
+        Ok(Deserialize::begin(&mut self.element))
+    }
+    fn finish(&mut self) -> miniserde::Result<()> {
+        self.take();
+        *self.out = Some(ReadaheadBlock {
+            file: self.file,
+            offset: self.offset,
+            size: self.size,
+            ino: 0,
+            #[cfg(feature = "readahead-debug")]
+            pid: 0,
+        });
+        Ok(())
+    }
+}
+
+impl Visitor for Place<ReadaheadBlock> {
+    fn seq(&mut self) -> miniserde::Result<Box<dyn miniserde::de::Seq + '_>> {
+        Ok(Box::new(ReadaheadBlockBuilder {
+            out: &mut self.out,
+            file: None,
+            offset: 0,
+            size: 0,
+            element: None,
+            pos: 0,
+        }))
+    }
+}
+
+impl Deserialize for ReadaheadBlock {
+    fn begin(out: &mut Option<Self>) -> &mut dyn Visitor {
+        Place::new(out)
+    }
+}
+
+fn write_file(filename: &str, data: &str) -> std::result::Result<(), String> {
+    write(filename, data).map_err(|e| format!("Failed to write {filename}: {e}"))
+}
+
+pub fn enable_readahead_tracing(enable: bool) -> Result<()> {
+    let value = if enable { "1" } else { "0" };
+    write_file(
+        "/sys/kernel/tracing/events/filemap/mm_filemap_add_to_page_cache/enable",
+        value,
+    )?;
+    write_file("/sys/kernel/tracing/tracing_on", value)?;
+    Ok(())
+}
+
+fn open_trace(cpu: u8) -> Result<File> {
+    Ok(OpenOptions::new()
+        .read(true)
+        .custom_flags(O_NONBLOCK)
+        .open(format!(
+            "/sys/kernel/tracing/per_cpu/cpu{cpu}/trace_pipe_raw"
+        ))?)
+}
+
+fn open_traces() -> Result<Vec<TraceFile>> {
+    let mut i: u8 = 0;
+    let mut traces: Vec<TraceFile> = Vec::new();
+
+    while let Ok(trace_file) = open_trace(i) {
+        let (pipe_read, pipe_write) = pipe().unwrap();
+        traces.push(TraceFile {
+            trace: trace_file,
+            tmp: OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(O_NONBLOCK | O_TMPFILE)
+                .open("/run")
+                .map_err(|e| format!("Failed to create temporary file in /run: {e}"))?,
+            cpu: i as usize,
+            pipe_read,
+            pipe_write,
+        });
+        i += 1;
+    }
+    Ok(traces)
+}
+
+fn do_splice<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
+    src: Fd1,
+    dst: Fd2,
+    flags: SpliceFFlags,
+    cpu: usize,
+) -> Result<bool> {
+    match splice(src, None, dst, None, 4096, flags) {
+        Ok(count) => {
+            if count < 4096 {
+                return Err(format!(
+                    "unexpected short ({count}) short trace buffer read for cpu{cpu}"
+                )
+                .into());
+            }
+        }
+        Err(Errno::EAGAIN) => {
+            return Ok(false);
+        }
+        Err(err) => {
+            return Err(format!("Unexpected error reading trace buffer for cpu{cpu}: {err}").into())
+        }
+    }
+    Ok(true)
+}
+
+fn read_trace(file: &TraceFile) -> Result<()> {
+    let mut flags = SpliceFFlags::empty();
+    flags.insert(SpliceFFlags::SPLICE_F_NONBLOCK);
+    flags.insert(SpliceFFlags::SPLICE_F_MOVE);
+    loop {
+        if !do_splice(&file.trace, &file.pipe_write, flags, file.cpu)? {
+            break;
+        }
+        do_splice(&file.pipe_read, &file.tmp, flags, file.cpu)?;
+    }
+    Ok(())
+}
+
+macro_rules! trace_pop {
+    ($T:ty, $data:expr) => {{
+        let start = $data.page * 4096 + $data.page_offset;
+        let size = size_of::<$T>();
+        $data.page_offset += size;
+        <$T>::from_ne_bytes($data.mmap[start..start + size].try_into().unwrap())
+    }};
+}
+
+macro_rules! trace_read {
+    ($T:ty, $data:expr, $offset:expr) => {{
+        let start = $data.page * 4096 + $data.page_offset + $offset;
+        let size = size_of::<$T>();
+        <$T>::from_ne_bytes($data.mmap[start..start + size].try_into().unwrap())
+    }};
+}
+
+fn split_type_len(type_len_ts: u32) -> (u32, u64) {
+    (type_len_ts & ((1 << 5) - 1), (type_len_ts >> 5) as u64)
+}
+
+fn trace_next(data: &mut TraceData) {
+    data.page_offset = data.record_end;
+    loop {
+        if data.page_offset >= data.page_size {
+            if data.page + 1 == data.pages {
+                // end of the trace reached
+                data.timestamp = u64::MAX;
+                return;
+            }
+            data.page += 1;
+            start_trace_page(data);
+        }
+        let type_len_ts = trace_pop!(u32, data);
+        let (type_len, delta) = split_type_len(type_len_ts);
+        match type_len {
+            KBUFFER_TYPE_PADDING => {
+                // padding size includes type_len_ts
+                let padding = trace_pop!(u32, data) as usize - 4;
+                assert!(data.page_offset + padding <= data.page_size);
+                data.page_offset += padding;
+                data.timestamp += delta;
+            }
+            KBUFFER_TYPE_TIME_EXTEND => {
+                let extend = trace_pop!(u32, data) as u64;
+                data.timestamp += (extend << 17) + delta;
+            }
+            KBUFFER_TYPE_TIME_STAMP => {
+                let extend = trace_pop!(u32, data) as u64;
+                data.timestamp = (data.timestamp & (0xf8 << 56)) + (extend << 27) + delta;
+            }
+            _ => {
+                data.record_end = data.page_offset
+                    + if type_len == 0 {
+                        ((trace_pop!(u32, data) as usize - 4) + 3) & !3
+                    } else {
+                        type_len as usize * 4
+                    };
+                data.timestamp += delta;
+                data.record_type = trace_read!(u16, data, 0);
+                break;
+            }
+        }
+    }
+    assert!(data.page_offset < data.page_size);
+}
+
+fn start_trace_page(data: &mut TraceData) {
+    data.page_offset = 0;
+    data.timestamp = trace_pop!(u64, data);
+    let flags: u64 = if SIZE_OF_LONG == 8 {
+        trace_pop!(u64, data)
+    } else {
+        trace_pop!(u32, data) as u64
+    };
+    data.page_size = (flags & ((1 << 27) - 1)) as usize + data.page_offset;
+    data.record_end = data.page_offset;
+}
+
+fn setup_trace_data(file: &TraceFile) -> Option<TraceData> {
+    if fstat(&file.tmp).unwrap().st_size == 0 {
+        return None;
+    }
+    let mmap = unsafe { Mmap::map(&file.tmp) }.unwrap();
+    let pages = mmap.len() / 4096;
+    let mut data = TraceData {
+        mmap,
+        pages,
+        timestamp: 0,
+        page: 0,
+        page_size: 0,
+        page_offset: 0,
+        record_end: 0,
+        record_type: 0,
+    };
+    start_trace_page(&mut data);
+    trace_next(&mut data);
+    Some(data)
+}
+
+fn find_paths(
+    dir: &Path,
+    root_dev: u64,
+    data: &mut Vec<ReadaheadBlock>,
+    map: &HashMap<u64, Vec<usize>>,
+    files: &mut Vec<String>,
+) -> Result<()> {
+    for entry in read_dir(dir)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.dev() != root_dev {
+            continue;
+        }
+        let path = entry.path();
+        if metadata.is_dir() {
+            find_paths(&path, root_dev, data, map, files)?;
+        } else if let Some(list) = map.get(&metadata.ino()) {
+            let index = files.len();
+            files.push(path.to_str().unwrap().to_string());
+            for i in list {
+                data[*i].file = Some(index);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn readahead_start_trace() -> Result<()> {
+    mount_apivfs(
+        "/sys/kernel//tracing",
+        "tracefs",
+        MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_NODEV,
+        None,
+    )?;
+    enable_readahead_tracing(true)?;
+    Ok(())
+}
+
+pub fn readahead_trace(_verify: bool) -> Result<ReadaheadData> {
+    let traces = open_traces()?;
+    let mut fds: Vec<PollFd> = traces
+        .iter()
+        .map(|trace| PollFd::new(trace.trace.as_fd(), PollFlags::POLLIN))
+        .collect();
+    let mut mask = SigSet::empty();
+    mask.add(Signal::SIGHUP);
+    mask.add(Signal::SIGINT);
+    mask.add(Signal::SIGTERM);
+    mask.thread_block().unwrap();
+    let sigfd = SignalFd::new(&mask).unwrap();
+    fds.push(PollFd::new(sigfd.as_fd(), PollFlags::POLLIN));
+    'main: loop {
+        let mut ready = ppoll(&mut fds, None, Some(mask))?;
+        if ready == 0 {
+            break;
+        }
+        // check trace fds
+        for (i, fd) in fds.split_last().unwrap().1.iter().enumerate() {
+            if fd.any().unwrap_or_default() {
+                read_trace(&traces[i])?;
+                ready -= 1;
+            }
+            if ready == 0 {
+                break;
+            }
+        }
+        if ready != 0 {
+            // check signal fd
+            if fds.last().unwrap().any().unwrap_or_default() {
+                break 'main;
+            } else {
+                break;
+            }
+        }
+    }
+    debug!("Stop readahead tracing...");
+    enable_readahead_tracing(false)?;
+
+    let format =
+        read_file("/sys/kernel/tracing/events/filemap/mm_filemap_add_to_page_cache/format")?;
+    let format: Vec<&str> = format.split("\n").collect();
+    // The second line contains "ID: <id>"
+    assert!(format[1][..4] == *"ID: ");
+    let id = format[1][4..].to_string().parse::<u16>().unwrap();
+
+    for trace in traces.iter() {
+        read_trace(trace)?;
+    }
+    let mut data: Vec<TraceData> = traces.iter().filter_map(setup_trace_data).collect();
+    if data.is_empty() {
+        return Err("No trace data!".into());
+    }
+    let root_metadata = metadata("/").unwrap();
+    let root_dev = root_metadata.dev();
+    let root_major = major(root_dev);
+    let root_minor = minor(root_dev);
+
+    let large = SIZE_OF_LONG == 8;
+    let mut readahead_data: Vec<ReadaheadBlock> = Vec::new();
+    let mut readahead_map: HashMap<u64, Vec<usize>> = HashMap::new();
+    loop {
+        let mut next: usize = 0;
+        for (i, trace_data) in data.iter().enumerate().skip(1) {
+            if trace_data.timestamp < data[next].timestamp {
+                next = i;
+            }
+        }
+        let trace_data = &mut data[next];
+        if trace_data.timestamp == u64::MAX {
+            break;
+        }
+        if trace_data.record_type != id {
+            warn!(
+                "Skipping unexpected record type {} for cpu{next}",
+                trace_data.record_type
+            );
+            trace_next(trace_data);
+            continue;
+        }
+        let s_dev = trace_read!(u32, trace_data, if large { 32 } else { 20 });
+        let minor = (s_dev & ((1 << 8) - 1)) as u64;
+        let major = (s_dev >> 20) as u64;
+        if major == root_major && minor == root_minor {
+            let ino = if large {
+                trace_read!(u64, trace_data, 16)
+            } else {
+                trace_read!(u32, trace_data, 12) as u64
+            };
+            let mut offset = if large {
+                trace_read!(u64, trace_data, 24)
+            } else {
+                trace_read!(u32, trace_data, 16) as u64
+            };
+            let mut size = 1 << trace_read!(u8, trace_data, if large { 36 } else { 24 });
+            #[cfg(feature = "readahead-debug")]
+            let pid = trace_read!(u32, trace_data, 4);
+            if let Some(last) = readahead_data.last() {
+                // merge blocks if possible
+                if last.ino == ino && last.offset + last.size == offset {
+                    offset = last.offset;
+                    size += last.size;
+                    readahead_data.pop();
+                }
+            }
+            readahead_data.push(ReadaheadBlock {
+                file: None,
+                offset,
+                size,
+                ino,
+                #[cfg(feature = "readahead-debug")]
+                pid,
+            });
+            let index = readahead_data.len() - 1;
+            readahead_map
+                .entry(ino)
+                .and_modify(|list| list.push(index))
+                .or_insert(Vec::from([index]));
+        }
+        trace_next(trace_data);
+    }
+    let mut files = Vec::new();
+    find_paths(
+        Path::new("/"),
+        root_dev,
+        &mut readahead_data,
+        &readahead_map,
+        &mut files,
+    )?;
+    #[cfg(feature = "readahead-debug")]
+    if _verify {
+        let pid = process::id();
+        for block in readahead_data.iter() {
+            if block.pid != pid {
+                debug!(
+                    "pid: {:8} offset {:3} blocks: {:3} {}",
+                    block.pid,
+                    block.offset,
+                    block.size,
+                    if let Some(file) = block.file {
+                        files[file].to_string()
+                    } else {
+                        block.ino.to_string()
+                    }
+                );
+            }
+        }
+    }
+    readahead_data.retain(|block| block.file.is_some());
+    let readahead = ReadaheadData {
+        files,
+        blocks: readahead_data,
+    };
+    Ok(readahead)
+}
+
+pub fn readahead_write(readahead: &ReadaheadData, filename: &str) -> Result<()> {
+    debug!("Writing readahead file {filename}.");
+    write_file(filename, &json::to_string(&readahead))?;
+    Ok(())
+}
+
+fn try_open(filename: &str) -> Option<OwnedFd> {
+    match File::open(filename) {
+        Ok(file) => Some(OwnedFd::from(file)),
+        Err(err) => {
+            debug!("Failed to open {filename}: {err}");
+            None
+        }
+    }
+}
+
+pub fn readahead_load(readahead: &ReadaheadData) {
+    let mut fds: HashMap<usize, Option<OwnedFd>> = HashMap::new();
+    for block in readahead.blocks.iter() {
+        let index = block.file.unwrap();
+        if let Some(fd) = fds
+            .entry(index)
+            .or_insert_with(|| try_open(&readahead.files[index]))
+        {
+            posix_fadvise(
+                fd,
+                (block.offset * 4096) as off_t,
+                (block.size * 4096) as off_t,
+                POSIX_FADV_WILLNEED,
+            )
+            .unwrap();
+        }
+    }
+    fds.clear();
+    debug!("Readahead done.");
+}
+
+fn readahead_run(trace_file: &str, input: Option<ReadaheadData>) -> Result<()> {
+    if let Some(input) = input {
+        readahead_load(&input);
+        let _ = readahead_trace(true)?;
+    } else {
+        let readahead = readahead_trace(false)?;
+        readahead_write(&readahead, trace_file)?;
+    }
+    Ok(())
+}
+
+pub fn readahead_open(trace_file: &str) -> Result<Option<ReadaheadData>> {
+    if Path::new(trace_file).exists() {
+        debug!("Loading readahead file {trace_file}...");
+        let data = read_file(trace_file)?;
+        let readahead: ReadaheadData = json::from_str(&data)?;
+        Ok(Some(readahead))
+    } else {
+        debug!("Readahead file {trace_file} not found. Start tracing...");
+        Ok(None)
+    }
+}
+
+pub fn readahead_start(input: Option<ReadaheadData>, trace_file: &str) -> Result<()> {
+    if let Err(err) = readahead_start_trace() {
+        error!("Start tracing failed with: {err}");
+        if input.is_none() {
+            return Ok(());
+        }
+    }
+    match unsafe { fork() } {
+        Ok(ForkResult::Parent { child, .. }) => {
+            debug!("Started readahead as pid {child}");
+            return Ok(());
+        }
+        Ok(ForkResult::Child) => {
+            // for rust 1.75
+            #[allow(clippy::manual_c_str_literals)]
+            let _ = set_name(CStr::from_bytes_with_nul(b"readahead\0").unwrap());
+            if let Err(err) = readahead_run(trace_file, input) {
+                error!("Readahead failed with{err}");
+            }
+            exit(0);
+        }
+        Err(err) => error!("Fork readahead process failed: {err}!"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
This is based on the ideas from ureadahead, specifically the modified version by Steven Rostedt that uses the mm_filemap_add_to_page_cache trace event.
It forks a separate process before executing the actuall init and supports recording and replaying a trace with a custom json format.