### PR TITLE
mount: encode the root device in the source of an overlayfs

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -187,7 +187,7 @@ impl<'a> InitContext<'a> {
     }
 
     pub fn mount_tmpfs_root_overlay(self: &InitContext<'a>) -> Result<()> {
-        mount_tmpfs_overlay(self.options.rootfsflags, "/")
+        mount_tmpfs_overlay(self.options.rootfsflags, "/", self.options.root.as_deref())
     }
 
     pub fn mount_root_overlay(
@@ -195,7 +195,13 @@ impl<'a> InitContext<'a> {
         data: Option<&str>,
         upper: &str,
     ) -> Result<()> {
-        mount_overlay(self.options.rootfsflags, data, upper, "/")
+        mount_overlay(
+            self.options.rootfsflags,
+            data,
+            upper,
+            "/",
+            self.options.root.as_deref(),
+        )
     }
 
     pub fn start_init(self: &InitContext<'a>) -> Result<()> {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -106,6 +106,7 @@ pub fn mount_overlay(
     data: Option<&str>,
     upper: &str,
     mountpoint: &str,
+    name: Option<&str>,
 ) -> Result<()> {
     let upperdir = format!("{upper}/upperdir");
     let workdir = format!("{upper}/workdir");
@@ -120,7 +121,7 @@ pub fn mount_overlay(
     mkdir(&workdir)?;
 
     do_mount(
-        Option::<&str>::None,
+        name,
         &mountdir,
         Some("overlay"),
         flags,
@@ -131,7 +132,11 @@ pub fn mount_overlay(
     Ok(())
 }
 
-pub fn mount_tmpfs_overlay(overlayflags: MsFlags, mountpoint: &str) -> Result<()> {
+pub fn mount_tmpfs_overlay(
+    overlayflags: MsFlags,
+    mountpoint: &str,
+    name: Option<&str>,
+) -> Result<()> {
     let dir = "/.overlay";
 
     mkdir(dir)?;
@@ -148,6 +153,7 @@ pub fn mount_tmpfs_overlay(overlayflags: MsFlags, mountpoint: &str) -> Result<()
         Some("redirect_dir=on,index=on,metacopy=on,volatile"),
         dir,
         mountpoint,
+        name,
     )?;
     umount(dir).map_err(|e| format!("Failed to unmount {dir}: {e}"))?;
     remove_dir(dir)?;


### PR DESCRIPTION
When a overlayfs is mounted over the whole rootfs, the original device that was mounted is no longer visible.
The source is not actually used for overlayfs so we can just put the original root device there to make is visible in mountinfo.