### PR TITLE
mount: sync apifs mount options with systemd

### DIFF
--- a/src/mount.rs
+++ b/src/mount.rs
@@ -32,15 +32,8 @@ pub fn do_mount(
     Ok(())
 }
 
-pub fn mount_apivfs(dst: &str, fstype: &str) -> Result<()> {
-    do_mount(
-        Some(fstype),
-        dst,
-        Some(fstype),
-        MsFlags::empty(),
-        Option::<&str>::None,
-    )?;
-
+pub fn mount_apivfs(dst: &str, fstype: &str, flags: MsFlags, data: Option<&str>) -> Result<()> {
+    do_mount(Some(fstype), dst, Some(fstype), flags, data)?;
     Ok(())
 }
 
@@ -88,9 +81,24 @@ fn mount_move(src: &str, dst: &str, cleanup: bool) -> Result<()> {
 }
 
 pub fn mount_special() -> Result<()> {
-    mount_apivfs("/dev", "devtmpfs")?;
-    mount_apivfs("/sys", "sysfs")?;
-    mount_apivfs("/proc", "proc")?;
+    mount_apivfs(
+        "/dev",
+        "devtmpfs",
+        MsFlags::MS_NOSUID | MsFlags::MS_STRICTATIME,
+        Some("mode=0755,size=4m"),
+    )?;
+    mount_apivfs(
+        "/sys",
+        "sysfs",
+        MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_NODEV,
+        None,
+    )?;
+    mount_apivfs(
+        "/proc",
+        "proc",
+        MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_NODEV,
+        None,
+    )?;
     Ok(())
 }
 

--- a/src/usbg_9pfs.rs
+++ b/src/usbg_9pfs.rs
@@ -7,6 +7,7 @@ use std::os::unix::fs::symlink;
 use std::{thread, time};
 
 use log::debug;
+use nix::mount::MsFlags;
 
 use crate::cmdline::CmdlineOptions;
 use crate::mount::mount_apivfs;
@@ -26,7 +27,7 @@ fn setup_9pfs_gadget(device: &String) -> Result<()> {
         .map_err(|e| format!("Failed to inspect the first entry in /sys/class/udc: {e}"))?
         .file_name();
 
-    mount_apivfs("/sys/kernel/config", "configfs")?;
+    mount_apivfs("/sys/kernel/config", "configfs", MsFlags::empty(), None)?;
 
     mkdir("/sys/kernel/config/usb_gadget/9pfs")?;
 


### PR DESCRIPTION
Systemd has reasonable defaults. Use the same so that the userspace sees the same options, whether rsinit is used or not.