### PR TITLE
cmdline: apply a simplification suggested by cargo clippy

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -158,26 +158,24 @@ impl<'a> CmdlineOptionsParser<'a> {
                     quoted = !quoted;
                     skip = true;
                 }
-                ' ' | '\n' => {
-                    if !quoted {
-                        if !have_value {
-                            key = &cmdline[start..i];
-                        }
-                        if !key.is_empty() {
-                            options.parse_option(
-                                key,
-                                if have_value {
-                                    Some(&cmdline[start..i])
-                                } else {
-                                    None
-                                },
-                                &mut self.callbacks,
-                            )?;
-                        }
-                        key = &cmdline[0..0];
-                        have_value = false;
-                        skip = true;
+                ' ' | '\n' if !quoted => {
+                    if !have_value {
+                        key = &cmdline[start..i];
                     }
+                    if !key.is_empty() {
+                        options.parse_option(
+                            key,
+                            if have_value {
+                                Some(&cmdline[start..i])
+                            } else {
+                                None
+                            },
+                            &mut self.callbacks,
+                        )?;
+                    }
+                    key = &cmdline[0..0];
+                    have_value = false;
+                    skip = true;
                 }
                 _ => {}
             }


### PR DESCRIPTION
Cargo clippy has recently learned folding if statements into `match` arms where appropriate. This change was performed by `cargo clippy --fix`.

This should fix the CI failures seen in [runs/24722960301](https://github.com/pengutronix/rsinit/actions/runs/24722960301).