### PR TITLE
init: move error logging into InitContext::run

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -27,7 +27,7 @@ use crate::mount::{
     mount_tmpfs_overlay,
 };
 #[cfg(feature = "systemd")]
-use crate::systemd::mount_systemd;
+use crate::systemd::{mount_systemd, shutdown};
 #[cfg(feature = "usb9pfs")]
 use crate::usbg_9pfs::prepare_9pfs_gadget;
 use crate::util::Result;
@@ -232,7 +232,21 @@ impl<'a> InitContext<'a> {
         Ok(())
     }
 
-    pub fn run(self: &mut InitContext<'a>) -> Result<()> {
+    pub fn run(self: &mut InitContext<'a>, cmd: &str) {
+        // log isn't setup at this point
+        println!("Running {cmd}...");
+        let result = match cmd {
+            #[cfg(feature = "systemd")]
+            "/shutdown" => shutdown(),
+            _ => self.run_impl(),
+        };
+
+        if let Err(e) = result {
+            println!("{e}");
+        }
+    }
+
+    fn run_impl(self: &mut InitContext<'a>) -> Result<()> {
         self.setup()?;
 
         #[cfg(any(feature = "dmverity", feature = "usb9pfs"))]
@@ -244,9 +258,7 @@ impl<'a> InitContext<'a> {
             mount_bind_kernel_modules()?;
         }
 
-        self.finish()?;
-
-        Ok(())
+        self.finish()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,22 +6,13 @@ use std::env;
 extern crate rsinit;
 
 use rsinit::init::InitContext;
-#[cfg(feature = "systemd")]
-use rsinit::systemd::shutdown;
 use rsinit::util::Result;
 
 fn main() -> Result<()> {
     let mut init = InitContext::new()?;
 
     let cmd = env::args().next().ok_or("No cmd to run as found")?;
-    println!("Running {cmd}...");
+    init.run(&cmd);
 
-    if let Err(e) = match cmd.as_str() {
-        #[cfg(feature = "systemd")]
-        "/shutdown" => shutdown(),
-        _ => init.run(),
-    } {
-        println!("{e}");
-    }
     Ok(())
 }


### PR DESCRIPTION
If run returned an error, this error was not printed to the console as the context object was dropped before the println statement. The drop implementation of InitContext flushes the console and triggers a reboot if feature `reboot-on-failure` is active, which is the default thus preventing the println statement to be reached.

Instead of printing the error outside the InitContext::run implementation move it into the method.