### PR TITLE
init: add callbacks for custom logic in the boot flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,66 @@ rsinit will refuse to bind-mount `/lib/modules` with an error if:
 1. `/lib/modules/<uname --kernel-release>` does not exist
 2. `/lib/modules/` contains files or folders which do not match the current kernel release
 
+rsinit as a library
+-------------------
+
+### Modification using callbacks
+
+When using `rsinit` as a crate in a custom implementation, you can use callbacks
+to extend its functionality without modifying the core logic.
+The [`nfs-bind-mounts`](examples/nfs-bind-mounts.rs) example contains a fully
+working example implementation.
+
+#### Command Line Parser Callbacks
+
+You can register callbacks to parse custom kernel command-line parameters.
+This is useful when your custom initialization logic requires parameters that the
+built-in parser does not handle.
+
+```rust
+use std::cell::RefCell;
+use rsinit::cmdline::ensure_value;
+use rsinit::init::InitContext;
+
+let custom_option = RefCell::new(String::new());
+let mut ctx = InitContext::new()?;
+
+ctx.add_cmdline_parser_callback(|key, val| {
+    if key == "my.option" {
+        *custom_option.borrow_mut() = ensure_value(key, val)?.to_owned();
+    }
+    Ok(())
+});
+ctx.run_from_env()?;
+```
+
+#### Init Callbacks
+
+Init callbacks allow you to execute custom logic at specific life cycle phases
+during the initialization process.
+The available phases are defined in the `CallBack` enum:
+
+- `PostSetup`: Executed after the initial setup (mounting special filesystems,
+  setting up logging, and parsing cmdline).
+- `PostRootMount`: Executed after the root filesystem has been mounted, before
+  switching root.
+- `PostSwitchRoot`: Executed after switching the root filesystem, before
+  starting the next init process.
+
+You can register multiple callbacks for the same phase, and they will be
+executed in the order they were registered.
+
+```rust
+use rsinit::init::{CallBack, InitContext};
+
+let mut ctx = InitContext::new()?;
+ctx.add_callback(CallBack::PostRootMount, |ctx| {
+    println!("The root filesystem has been mounted!");
+    Ok(())
+});
+ctx.run_from_env()?;
+```
+
 Cross compilation with cross.rs
 -------------------------------
 

--- a/examples/nfs-bind-mounts.rs
+++ b/examples/nfs-bind-mounts.rs
@@ -43,9 +43,7 @@ fn main() -> Result<()> {
     let mount_args = RefCell::new(MountArgs::default());
 
     let mut ctx = InitContext::new()?;
-    ctx.add_cmdline_parser_callback(Box::new(|key, value| {
-        mount_args.borrow_mut().parse_cmdline(key, value)
-    }));
+    ctx.add_cmdline_parser_callback(|key, value| mount_args.borrow_mut().parse_cmdline(key, value));
 
     if let Err(e) = run(&mut ctx, &mount_args) {
         println!("{e}");

--- a/examples/nfs-bind-mounts.rs
+++ b/examples/nfs-bind-mounts.rs
@@ -1,41 +1,16 @@
 // SPDX-FileCopyrightText: 2026 The rsinit Authors
 // SPDX-License-Identifier: GPL-2.0-only
 
+use std::cell::RefCell;
 use std::net::IpAddr;
-use std::{cell::RefCell, env};
 
 extern crate rsinit;
 
 use log::{error, info};
 use nix::mount::MsFlags;
 use rsinit::mount::do_mount;
-#[cfg(feature = "systemd")]
-use rsinit::systemd::shutdown;
 use rsinit::util::Result;
 use rsinit::{cmdline::ensure_value, init::InitContext};
-
-fn run(ctx: &mut InitContext, mount_args: &RefCell<MountArgs>) -> Result<()> {
-    let cmd = env::args().next().ok_or("No cmd to run as found")?;
-    println!("Running {cmd}...");
-
-    match cmd.as_str() {
-        #[cfg(feature = "systemd")]
-        "/shutdown" => shutdown(),
-        _ => {
-            ctx.setup()?;
-
-            #[cfg(any(feature = "dmverity", feature = "usb9pfs"))]
-            ctx.prepare_aux()?;
-
-            ctx.mount_root()?;
-
-            mount_args.borrow_mut().do_mounts()?;
-
-            ctx.finish()?;
-            Ok(())
-        }
-    }
-}
 
 fn main() -> Result<()> {
     // This object needs to be alive as long as the InitContext is alive! The RefCell allows us to
@@ -44,14 +19,10 @@ fn main() -> Result<()> {
 
     let mut ctx = InitContext::new()?;
     ctx.add_cmdline_parser_callback(|key, value| mount_args.borrow_mut().parse_cmdline(key, value));
-
-    if let Err(e) = run(&mut ctx, &mount_args) {
-        println!("{e}");
-    }
-
-    drop(ctx);
-
-    Ok(())
+    ctx.add_callback(rsinit::init::CallBack::PostRootMount, |_ctx| {
+        mount_args.borrow_mut().do_mounts()
+    });
+    ctx.run_from_env()
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -48,7 +48,7 @@ impl CmdlineOptions {
         &mut self,
         key: &str,
         value: Option<&str>,
-        callbacks: &mut [Box<CmdlineCallback<'a>>],
+        callbacks: &mut [Box<dyn CmdlineCallback + 'a>],
     ) -> Result<()> {
         match key {
             "root" => self.root = Some(ensure_value(key, value)?.to_string()),
@@ -62,7 +62,7 @@ impl CmdlineOptions {
             "rsinit.bind_modules" => self.bind_modules = true,
             _ => {
                 for cb in callbacks {
-                    cb(key, value)?
+                    cb.call(key, value)?
                 }
             }
         }
@@ -115,11 +115,22 @@ impl CmdlineOptions {
     }
 }
 
-pub type CmdlineCallback<'a> = dyn FnMut(&str, Option<&str>) -> Result<()> + 'a;
+pub trait CmdlineCallback {
+    fn call(&mut self, key: &str, value: Option<&str>) -> Result<()>;
+}
+
+impl<F> CmdlineCallback for F
+where
+    F: FnMut(&str, Option<&str>) -> Result<()>,
+{
+    fn call(&mut self, key: &str, value: Option<&str>) -> Result<()> {
+        self(key, value)
+    }
+}
 
 #[derive(Default)]
 pub struct CmdlineOptionsParser<'a> {
-    callbacks: Vec<Box<CmdlineCallback<'a>>>,
+    callbacks: Vec<Box<dyn CmdlineCallback + 'a>>,
 }
 
 impl<'a> CmdlineOptionsParser<'a> {
@@ -127,7 +138,7 @@ impl<'a> CmdlineOptionsParser<'a> {
         Self::default()
     }
 
-    pub fn add_callback(&mut self, cb: Box<CmdlineCallback<'a>>) {
+    pub fn add_callback(&mut self, cb: Box<dyn CmdlineCallback + 'a>) {
         self.callbacks.push(cb);
     }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -159,22 +159,25 @@ impl<'a> InitContext<'a> {
     /// use rsinit::cmdline::ensure_value;
     /// use rsinit::init::InitContext;
     ///
-    /// let mut custom_option = RefCell::new(String::new());
+    /// let custom_option = RefCell::new(String::new());
     /// let mut ctx = InitContext::new()?;
     ///
-    /// ctx.add_cmdline_parser_callback(Box::new(|key, val| {
+    /// ctx.add_cmdline_parser_callback(|key, val| {
     ///     if key == "my.option" {
     ///         *custom_option.borrow_mut() = ensure_value(key, val)?.to_owned();
     ///     }
     ///     Ok(())
-    /// }));
+    /// });
     ///
     /// // When `setup()` parses /proc/cmdline, the callback will be invoked
     /// ctx.setup()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn add_cmdline_parser_callback(&mut self, cb: Box<CmdlineCallback<'a>>) {
-        self.parser.add_callback(cb);
+    pub fn add_cmdline_parser_callback<F>(&mut self, cb: F)
+    where
+        F: FnMut(&str, Option<&str>) -> Result<()> + 'a,
+    {
+        self.parser.add_callback(Box::new(cb));
     }
 
     /// Register a callback to be executed during a specific lifecycle phase.

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,6 +9,7 @@ use std::fmt::Write as _;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::Write as _;
+use std::mem::take;
 use std::os::fd::AsFd;
 use std::os::unix::ffi::OsStrExt;
 use std::panic::set_hook;
@@ -19,7 +20,7 @@ use nix::sys::reboot::{reboot, RebootMode};
 use nix::sys::termios::tcdrain;
 use nix::unistd::{chdir, chroot, dup2_stderr, dup2_stdout, execv, unlink};
 
-use crate::cmdline::{CmdlineCallback, CmdlineOptions, CmdlineOptionsParser};
+use crate::cmdline::{CmdlineOptions, CmdlineOptionsParser};
 #[cfg(feature = "dmverity")]
 use crate::dmverity::prepare_dmverity;
 use crate::mount::{
@@ -89,9 +90,47 @@ fn finalize() {
     let _ = reboot(RebootMode::RB_AUTOBOOT);
 }
 
+/// The lifecycle phases where callbacks can be registered.
+///
+/// # Example
+///
+/// ```no_run
+/// use rsinit::init::{CallBack, InitContext};
+///
+/// let mut ctx = InitContext::new()?;
+/// ctx.add_callback(CallBack::PostSetup, |ctx| {
+///     println!("Post setup phase");
+///     Ok(())
+/// });
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CallBack {
+    /// Executed after the initial setup (mounting special filesystems, setting up logging, and parsing cmdline).
+    PostSetup,
+    /// Executed after the root filesystem has been mounted, before switching root.
+    PostRootMount,
+    /// Executed after switching the root filesystem, before starting the next init process.
+    PostSwitchRoot,
+}
+
+pub trait InitCallback {
+    fn call(&mut self, ctx: &mut InitContext) -> Result<()>;
+}
+
+impl<F> InitCallback for F
+where
+    F: FnMut(&mut InitContext) -> Result<()>,
+{
+    fn call(&mut self, ctx: &mut InitContext) -> Result<()> {
+        self(ctx)
+    }
+}
+
 pub struct InitContext<'a> {
     pub options: CmdlineOptions,
     parser: CmdlineOptionsParser<'a>,
+    callbacks: Vec<(CallBack, Box<dyn InitCallback + 'a>)>,
 }
 
 impl<'a> InitContext<'a> {
@@ -106,6 +145,7 @@ impl<'a> InitContext<'a> {
         Ok(Self {
             options: CmdlineOptions::default(),
             parser: CmdlineOptionsParser::new(),
+            callbacks: Vec::default(),
         })
     }
 
@@ -135,6 +175,29 @@ impl<'a> InitContext<'a> {
     /// ```
     pub fn add_cmdline_parser_callback(&mut self, cb: Box<CmdlineCallback<'a>>) {
         self.parser.add_callback(cb);
+    }
+
+    /// Register a callback to be executed during a specific lifecycle phase.
+    ///
+    /// Callbacks are executed in the order they were registered for a given [`CallBack`] phase.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rsinit::init::{CallBack, InitContext};
+    ///
+    /// let mut ctx = InitContext::new()?;
+    /// ctx.add_callback(CallBack::PostRootMount, |ctx| {
+    ///     println!("The root filesystem has been mounted!");
+    ///     Ok(())
+    /// });
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn add_callback<F>(&mut self, kind: CallBack, cb: F)
+    where
+        F: FnMut(&mut InitContext) -> Result<()> + 'a,
+    {
+        self.callbacks.push((kind, Box::new(cb)));
     }
 
     pub fn setup(&mut self) -> Result<()> {
@@ -227,6 +290,7 @@ impl<'a> InitContext<'a> {
 
     pub fn finish(self: &mut InitContext<'a>) -> Result<()> {
         self.switch_root()?;
+        self.run_callbacks(CallBack::PostSwitchRoot)?;
         self.start_init()?;
 
         Ok(())
@@ -246,13 +310,31 @@ impl<'a> InitContext<'a> {
         }
     }
 
+    fn run_callbacks(self: &mut InitContext<'a>, target_kind: CallBack) -> Result<()> {
+        let mut cbs = take(&mut self.callbacks);
+
+        for (kind, ref mut cb) in cbs.iter_mut() {
+            if *kind == target_kind {
+                cb.call(self)?;
+            }
+        }
+
+        self.callbacks = cbs;
+
+        Ok(())
+    }
+
     fn run_impl(self: &mut InitContext<'a>) -> Result<()> {
         self.setup()?;
+
+        self.run_callbacks(CallBack::PostSetup)?;
 
         #[cfg(any(feature = "dmverity", feature = "usb9pfs"))]
         self.prepare_aux()?;
 
         self.mount_root()?;
+
+        self.run_callbacks(CallBack::PostRootMount)?;
 
         if self.options.bind_modules {
             mount_bind_kernel_modules()?;

--- a/src/init.rs
+++ b/src/init.rs
@@ -299,6 +299,24 @@ impl<'a> InitContext<'a> {
         Ok(())
     }
 
+    /// Run rsinit using the first argument from the commandline. If run under
+    /// systemd the argument is `shutdown`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rsinit::init::InitContext;
+    ///
+    /// let mut ctx = InitContext::new()?;
+    /// ctx.run_from_env()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn run_from_env(&mut self) -> Result<()> {
+        let cmd = env::args().next().ok_or("No cmd to run was found")?;
+        self.run(&cmd);
+        Ok(())
+    }
+
     pub fn run(self: &mut InitContext<'a>, cmd: &str) {
         // log isn't setup at this point
         println!("Running {cmd}...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,11 @@
 // SPDX-FileCopyrightText: 2024 The rsinit Authors
 // SPDX-License-Identifier: GPL-2.0-only
 
-use std::env;
-
 extern crate rsinit;
 
 use rsinit::init::InitContext;
 use rsinit::util::Result;
 
 fn main() -> Result<()> {
-    let mut init = InitContext::new()?;
-
-    let cmd = env::args().next().ok_or("No cmd to run as found")?;
-    init.run(&cmd);
-
-    Ok(())
+    InitContext::new()?.run_from_env()
 }


### PR DESCRIPTION
builds upon #36 

Rsinit is meant as a flexible library for custom initrd creation. For
most use cases it should be enough to hook into the default boot flow
with callbacks and add some custom logic. This ability is implemented in
this commit. The hook points are defined by the \`CallBack\` enum:

- PostSetup:
   Executed after the initial setup (mounting special filesystems, setting up logging, and parsing cmdline).

- PostRootMount:
   Executed after the root filesystem has been mounted, before switching root.

- PostSwitchRoot:
   Executed after switching the root filesystem, before starting the next init process.

More callbacks can be added in the future if necessary.