### PR TITLE
init: fix clippy lint about redundant `&` in `info!` call

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -259,7 +259,7 @@ impl<'a> InitContext<'a> {
             write!(buf, "{} ", arg.to_bytes().escape_ascii())?;
         }
         writeln!(buf, "...")?;
-        info!("{}", &buf);
+        info!("{}", buf);
 
         execv(&args[0], &args)?;
 


### PR DESCRIPTION
Clippy has recently learned a new trick:

```
error: redundant reference in `info!` argument
   --> src/init.rs:262:21
    |
262 |         info!("{}", &buf);
    |                     ^^^^ help: remove the redundant `&`: `buf`
    |
    = help: for further information visit https://rust-lang.github.io/…
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`
```

Change the code to make the CI happy again.