### PR TITLE
init: switch_root: support unshare(CLONE_NEWUSER)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ systemd = ["nix/reboot"]
 dmverity = ["nix/ioctl"]
 usb9pfs = []
 reboot-on-failure = ["nix/reboot"]
-integration-test = ["json", "nix/reboot"]
+integration-test = ["json", "nix/reboot", "nix/sched"]
 
 [profile.release]
 opt-level = 'z'

--- a/src/bin/integration-test.rs
+++ b/src/bin/integration-test.rs
@@ -4,8 +4,17 @@
 use std::fs::read_dir;
 use std::io;
 use std::process;
+use std::process::exit;
 
+use nix::errno::Errno;
+use nix::libc::{EXIT_FAILURE, EXIT_SUCCESS};
+use nix::sched::unshare;
+use nix::sched::CloneFlags;
 use nix::sys::reboot::{reboot, RebootMode};
+use nix::sys::wait::waitpid;
+use nix::sys::wait::WaitStatus;
+use nix::unistd::fork;
+use nix::unistd::ForkResult;
 use rsinit::integration::find_vport;
 use rsinit::util::{read_file, Result};
 
@@ -61,12 +70,37 @@ fn collect_block_devices() -> Result<json::JsonValue> {
     Ok(devices)
 }
 
+fn collect_root_mount() -> Result<json::JsonValue> {
+    match unsafe { fork() } {
+        Ok(ForkResult::Child) => match unshare(CloneFlags::CLONE_NEWUSER) {
+            Ok(_) => exit(EXIT_SUCCESS),
+            Err(Errno::EINVAL) => {
+                println!("Kernel does not support user namespaces, ignoring.");
+                exit(EXIT_SUCCESS);
+            }
+            _ => exit(EXIT_FAILURE),
+        },
+        Ok(ForkResult::Parent { child, .. }) => match waitpid(child, None) {
+            Ok(WaitStatus::Exited(_, status)) => {
+                let user_ns = status == EXIT_SUCCESS;
+                return Ok(json::JsonValue::Boolean(user_ns));
+            }
+            // Everything but a clean exit is a failure
+            _ => return Err("waitpid failed!".into()),
+        },
+        Err(err) => {
+            return Err(format!("Forking of user namespace canary process failed: {err}").into())
+        }
+    }
+}
+
 fn main() -> Result<()> {
     println!("Collecting system state...");
 
     let mut data = json::JsonValue::new_object();
     data["mountinfo"] = parse_mountinfo()?;
     data["block-devices"] = collect_block_devices()?;
+    data["root-mount"] = collect_root_mount()?;
 
     let pid = process::id();
     if pid == 1 {

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -20,6 +20,9 @@ pub struct CmdlineOptions {
     pub verity_root: Option<String>,
     pub nfsroot: Option<String>,
     pub init: String,
+    /// Run cleanup code during rootfs pivot/switch. True by default,
+    /// deactivated for systemd boots which runs rs-init again executing the
+    /// shutdown command.
     pub cleanup: bool,
     /// Attempt to bind-mount `/lib/modules` from the initrd at `/root/lib/modules`.
     ///

--- a/src/init.rs
+++ b/src/init.rs
@@ -14,10 +14,11 @@ use std::panic::set_hook;
 
 use git_version::git_version;
 use log::{error, info};
+use nix::mount::{umount2, MntFlags};
 #[cfg(feature = "reboot-on-failure")]
 use nix::sys::reboot::{reboot, RebootMode};
 use nix::sys::termios::tcdrain;
-use nix::unistd::{chdir, chroot, dup2_stderr, dup2_stdout, execv, unlink};
+use nix::unistd::{chdir, chroot, dup2_stderr, dup2_stdout, execv, pivot_root, unlink};
 
 use crate::cmdline::{CmdlineOptions, CmdlineOptionsParser};
 #[cfg(feature = "dmverity")]
@@ -27,8 +28,8 @@ use crate::integration::IntegrationLogger as Logger;
 #[cfg(not(feature = "integration-test"))]
 use crate::kmsg::KmsgLogger as Logger;
 use crate::mount::{
-    mount_bind_kernel_modules, mount_move_special, mount_overlay, mount_root, mount_special,
-    mount_tmpfs_overlay,
+    mount_bind_kernel_modules, mount_move, mount_move_special, mount_overlay, mount_root,
+    mount_special, mount_tmpfs_overlay,
 };
 #[cfg(feature = "systemd")]
 use crate::systemd::{mount_systemd, shutdown};
@@ -201,6 +202,20 @@ impl<'a> InitContext<'a> {
         Ok(())
     }
 
+    fn switch_root_pivot(self: &mut InitContext<'a>) -> Result<()> {
+        pivot_root(".", ".")?;
+        umount2(".", MntFlags::MNT_DETACH)?;
+
+        Ok(())
+    }
+
+    fn switch_root_move(self: &mut InitContext<'a>) -> Result<()> {
+        mount_move(".", "/", false)?;
+        chroot(".")?;
+
+        Ok(())
+    }
+
     pub fn switch_root(self: &mut InitContext<'a>) -> Result<()> {
         #[cfg(feature = "systemd")]
         mount_systemd(&mut self.options)?;
@@ -213,8 +228,11 @@ impl<'a> InitContext<'a> {
         mount_move_special(self.options.cleanup)?;
 
         chdir("/root")?;
-        chroot(".")?;
-        chdir("/")?;
+        if let Err(e) = self.switch_root_pivot() {
+            info!("pivot_root failed, moving mounts instead: {e}");
+            self.switch_root_move()?;
+        }
+
         Ok(())
     }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -264,6 +264,7 @@ impl<'a> InitContext<'a> {
         )
     }
 
+    #[allow(unreachable_code)]
     pub fn start_init(self: &InitContext<'a>) -> Result<()> {
         let mut args = Vec::new();
         args.push(CString::new(self.options.init.as_str())?);
@@ -281,7 +282,7 @@ impl<'a> InitContext<'a> {
 
         execv(&args[0], &args)?;
 
-        Ok(())
+        Ok(()) // Actually unreachable
     }
 
     pub fn finish(self: &mut InitContext<'a>) -> Result<()> {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -87,7 +87,7 @@ pub fn mount_root(
     Ok(())
 }
 
-fn mount_move(src: &str, dst: &str, cleanup: bool) -> Result<()> {
+pub fn mount_move(src: &str, dst: &str, cleanup: bool) -> Result<()> {
     mount(
         Some(Path::new(src)),
         dst,

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -62,6 +62,7 @@ fn umount_root() -> Result<()> {
     Ok(())
 }
 
+#[allow(unreachable_code)]
 pub fn shutdown() -> Result<()> {
     umount_root()?;
     let arg = match env::args().nth(1).as_deref() {
@@ -71,5 +72,6 @@ pub fn shutdown() -> Result<()> {
         _ => RebootMode::RB_AUTOBOOT,
     };
     reboot(arg).map_err(|e| format!("reboot failed: {e}"))?;
-    Ok(())
+
+    Ok(()) // Actually unreachable
 }

--- a/test/genimage.py
+++ b/test/genimage.py
@@ -58,7 +58,7 @@ class GenImage:
             ]
             if root:
                 args += ["--root", root.name]
-            subprocess.run(args, env=self._sbin_env()).check_returncode()
+            subprocess.run(args, env=self._sbin_env(), check=True)
 
     def __image_file(self, name):
         return self.__image_path / name

--- a/test/genimage.py
+++ b/test/genimage.py
@@ -170,10 +170,10 @@ image {name} {{
             for line in output:
                 try:
                     key, value = line.split(":", 1)
+                    value = value.strip().partition(" ")[0]
                 except ValueError:
                     continue
                 key = "VERITY_" + key.strip().upper().replace(" ", "_")
-                value = value.strip()
                 verity_config.write(f"{key}={value}\n")
             verity_config.write(f"VERITY_DATA_SECTORS={int(size / 512)}\n")
             return verity_params

--- a/test/qemu.py
+++ b/test/qemu.py
@@ -23,6 +23,10 @@ KERNEL_AARCH64_URL = None
 KERNEL_AARCH64_SHA256 = None
 
 
+class ChecksumError(Exception):
+    """Raised when a downloaded file does not match its expected sha256."""
+
+
 class RuntimeStatus:
     def __init__(self, result):
         result = [json.loads(block) for block in result.split("\0") if block]
@@ -104,7 +108,7 @@ class Qemu:
         with open(file, "rb") as f:
             digest = hashlib.file_digest(f, "sha256")
         if digest.hexdigest() != sha256:
-            raise Exception(
+            raise ChecksumError(
                 f"sha256 for {file} does not match: {digest.hexdigest()} != {sha256} (expected)"
             )
 
@@ -166,7 +170,7 @@ class Qemu:
                 "-device",
                 "virtserialport,chardev=rsinit,name=rsinit.result.0",
             ]
-            subprocess.run(args)
+            subprocess.run(args, check=False)
             return RuntimeStatus(result.read())
 
 

--- a/test/qemu.py
+++ b/test/qemu.py
@@ -34,15 +34,18 @@ class RuntimeStatus:
             self._system_status = result.pop(-1)
             self.mountinfo = self._system_status["mountinfo"]
             self.block_devices = self._system_status.get("block-devices")
+            self.root_mount = self._system_status.get("root-mount")
         else:
             self._system_status = None
             self.mountinfo = None
             self.block_devices = None
+            self.root_mount = None
         self.rsinit_messages = result
 
     def assert_system_state(self):
         assert self.mountinfo, "Missing /proc/self/mountinfo data"
         assert self.block_devices, "Missing /sys/dev/block data"
+        assert self.root_mount is True, "Invalid root mount"
 
     def get_mount(self, *, mount_point=None, filesystem_type=None):
         assert self.mountinfo, "missing mountinfo data"


### PR DESCRIPTION
This PR enables the usage of user namespaces with rs-init
bootstrapped systems. Previously any `unshare(CLONE_NEWUSER)` call
failed with EPERM as the requirement is:

```
EPERM (since Linux 3.9)
       CLONE_NEWUSER was specified in flags and the caller is in a
       chroot environment (i.e., the caller's root directory does not
       match the root directory of the mount namespace in which it
       resides).
```
Source: [1]

There are two solutions to the problem:

1. Newer kernels are able to use `pivot_root` inside an initramfs[2],
   which moves the root directory of the mount namespace as well.
2. Use `chroot(/root)` as before but move every mount from "/" to
   "/root" with `mount(MS_MOVE)`, replicating what `pivot_root` does.

The implementation mostly follows the systemd helper function
`mount_switch_root_full`[3].

[1]: https://man7.org/linux/man-pages/man2/unshare.2.html
[2]: https://lore.kernel.org/all/20260112-work-immutable-rootfs-v2-0-88dd1c34a204@kernel.org/T/#u
[3]: https://github.com/systemd/systemd/blob/25c0b10671fa956e7917f9e4b7727b130b328388/src/shared/mount-util.c#L510-L590